### PR TITLE
Basic width-selecting functionality

### DIFF
--- a/lib/generators/styleguide/templates/index.html.erb
+++ b/lib/generators/styleguide/templates/index.html.erb
@@ -5,6 +5,18 @@
       <%= render :partial => 'widget_link', :collection => @widgets, :as => :widget %>
     </ul>
     </li>
+    <li>
+      <span id='width-selector'>Width</span>
+  </ul>
+  <ul id='width-options'>
+    <li class='width-option' data-width='320px'>320</li>
+    <li class='width-option' data-width='480px'>480</li>
+    <li class='width-option' data-width='748px'>748</li>
+    <li class='width-option' data-width='960px'>960</li>
+    <li class='width-option' data-width='1024px'>1024</li>
+    <li class='width-option' data-width='1280px'>1280</li>
+    <li class='width-option' data-width='640px'>iPhone</li>
+    <li class='width-option' data-width='100%'>Full</li>
   </ul>
 </nav>
 <dl>

--- a/lib/generators/styleguide/templates/styleguide.css
+++ b/lib/generators/styleguide/templates/styleguide.css
@@ -71,6 +71,9 @@
 #styleguide_rails > nav > ul ul > li > a:hover {
   background: #4b545f;
 }
+#styleguide_rails > nav > #width-options {
+  display: none;
+}
 #styleguide_rails > dl {
   padding: 0 10px;
   margin: 0;
@@ -92,6 +95,7 @@
   border-left: 1px dashed #CCC;
   border-right: 1px dashed #CCC;
   border-top: 1px dashed #FFF;
+  margin: 0 auto;
 }
 #styleguide_rails > dl > dd > div.location {
   font-style: italic;

--- a/lib/generators/styleguide/templates/styleguide.js
+++ b/lib/generators/styleguide/templates/styleguide.js
@@ -397,3 +397,56 @@ Prism.hooks.add('wrap', function(env) {
     env.attributes['title'] = env.content.replace(/&amp;/, '&');
   }
 });;
+
+(function() {
+  var markAsSelected = function(selectedOption) {
+    var options = document.getElementById('width-options').getElementsByClassName('width-option');
+
+    for (var i = 0; i < options.length; i++) {
+      options[i].className = 'width-option';
+    }
+
+    selectedOption.className += ' selected';
+  };
+
+  var showHideWidth = function() {
+    var options = document.getElementById('width-options');
+    var display = options.style.display;
+
+    if (display === undefined || display === 'inline-table') {
+      options.style.display = 'none';
+    } else {
+      options.style.display = 'inline-table';
+    }
+  };
+
+  var changeWidth = function(event) {
+    var selectedOption, selectedWidth, previews;
+    selectedOption = event.target;
+    selectedWidth = selectedOption.getAttribute('data-width');
+    previews = document.getElementsByClassName('preview');
+
+    markAsSelected(selectedOption);
+
+    for (var i = 0; i < previews.length; i++) {
+      previews[i].style.width = selectedWidth;
+    }
+  };
+
+  var bindChangeWidth = function() {
+    var options = document.getElementById('width-options').getElementsByClassName('width-option');
+    for (var i = 0; i < options.length; i++) {
+      options[i].addEventListener('click', changeWidth);
+    }
+  };
+
+  var bindShowHideWidth = function() {
+    var widthSelector = document.getElementById('width-selector');
+    widthSelector.addEventListener('click', showHideWidth);
+  };
+
+  window.addEventListener && window.addEventListener('load', function() {
+    bindChangeWidth();
+    bindShowHideWidth();
+  });
+})();


### PR DESCRIPTION
This adds the following functionality:
- clicking an option sets the width on all preview elements
- show/hide on the width options
- `selected` class is set on clicked option

Note that most of this functionality is done via Javascript. Widths are currently set inline on the elements, but we can move those widths to CSS and classes if that's what you're into.

The major piece that's missing is the CSS for all of this. I know @micfunk was working on a new menu bar, so maybe it makes sense to wait for that before merging this in.
