### PR TITLE
Fixed ruby 1.8.7 syntax error in StyleguideController

### DIFF
--- a/lib/generators/styleguide/templates/styleguide_controller.rb
+++ b/lib/generators/styleguide/templates/styleguide_controller.rb
@@ -7,9 +7,9 @@ class StyleguideController < ApplicationController
     @widgets = widget_files.reduce([]) do |widgets, filename|
       lang = filename.match(/haml$/) ? 'haml' : 'markup'
 
-      name = File.basename(filename)
-                 .sub(/.html.*/, '')
-                 .sub(/^_/, '')
+      name = File.basename(filename).
+                 sub(/.html.*/, '').
+                 sub(/^_/, '')
 
       widgets << { :name       => name,
                    :filename   => filename,


### PR DESCRIPTION
Wasn't working for me in 1.8.7 so @psynix kindly made this fix. I'm just passing it on.
