### PR TITLE
separate the viewport list with commas

### DIFF
--- a/lib/generators/styleguide/install/templates/styleguide.html.erb
+++ b/lib/generators/styleguide/install/templates/styleguide.html.erb
@@ -4,7 +4,7 @@
     <title>Application Style Guide</title>
     <%= stylesheet_link_tag    "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
-    <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0;">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
     <!-- Bypass asset pipeline to protect other pages -->
     <script src="/javascripts/styleguide.js" type="text/javascript"></script>


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Mobile/Viewport_meta_tag and 
![viewport](https://f.cloud.github.com/assets/666493/459405/a30fda98-b400-11e2-9cc2-c6b9ada6e609.png)
