### PR TITLE
Pin to older guard

### DIFF
--- a/styleguide_rails.gemspec
+++ b/styleguide_rails.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rails", ">= 3.0.0"
   gem.add_dependency "guard-livereload", "~> 1.4.0"
+  gem.add_dependency "guard", "~> 1.8"
 end


### PR DESCRIPTION
`guard-livereload ~> 1.4.0` does a `require 'guard/guard'`, which doesn't seem to work with Guard 2.x.

Another possible fix would be to update to a newer version of `guard-livereload` that fixes this issue, but I haven't investigated whether that library brings in Guard 2.x properly or not.