### PR TITLE
Include jQuery

### DIFF
--- a/lib/generators/styleguide/install/templates/styleguide.html.erb
+++ b/lib/generators/styleguide/install/templates/styleguide.html.erb
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
     <!-- Bypass asset pipeline to protect other pages -->
+    <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="/javascripts/styleguide.js" type="text/javascript"></script>
     <link href="/stylesheets/styleguide.css" media="all" rel="stylesheet" type="text/css" />
   </head>


### PR DESCRIPTION
The style guide JS tries to use jQuery, but it's not pulled in. Using the CDN version here.