### PR TITLE
Livereload version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To enable live reloading,
 
 * Install the [LiveReload](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en)
   plugin for Google Chrome.
-* Add `gem 'guard'` to your `Gemfile`
+* Add `gem 'guard'` and `gem 'guard-livereload', '~> 2.4', require: false` to your `Gemfile`
 * Run `bundle`
 * Run `guard` in a new terminal window
 * Be sure you enable the LiveReload plugin in Chrome. Just click its

--- a/lib/styleguide_rails/version.rb
+++ b/lib/styleguide_rails/version.rb
@@ -1,3 +1,3 @@
 module StyleguideRails
-  VERSION = "0.3.5"
+  VERSION = "0.3.6"
 end

--- a/styleguide_rails.gemspec
+++ b/styleguide_rails.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rails", ">= 3.0.0"
   gem.add_dependency "guard-livereload", "~> 2.4.0"
-  gem.add_dependency "guard", "~> 1.8"
+  gem.add_dependency "guard", "~> 2.13"
 end

--- a/styleguide_rails.gemspec
+++ b/styleguide_rails.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "rails", ">= 3.0.0"
-  gem.add_dependency "guard-livereload", "~> 1.4.0"
+  gem.add_dependency "guard-livereload", "~> 2.4.0"
   gem.add_dependency "guard", "~> 1.8"
 end


### PR DESCRIPTION
We'd like to use Style Guide with LiveReload, so we updated the dependencies for guard to 2.13 and guard-livereload to 2.4.
